### PR TITLE
Refatora o logger

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+APP_NAME=note-sync
+LOG_FILE=../logs/note-sync.log
 DB_HOST=localhost
 DB_PORT=3306
 DB_NAME=database

--- a/Core/Account.php
+++ b/Core/Account.php
@@ -3,10 +3,6 @@
 namespace Core;
 
 use Core\Validator;
-use Monolog\Level;
-use Monolog\Logger;
-use Monolog\Handler\StreamHandler;
-use Core\Model;
 use Core\Models\UsersModel;
 
 class Account
@@ -35,8 +31,7 @@ class Account
 
     public function UpdateAccount($id, $password)
     {
-        $log = new Logger("conta usuario ");
-        $log->pushHandler(new StreamHandler("../logs/account.log", Level::Info));
+
         try {
             $erros = [];
             if (!Validator::string($password, 10, 50)) {
@@ -46,16 +41,16 @@ class Account
                 return $erros;
             }
             $this->usersModel->updateAccount($id, $password);
-            $log->info("senha atualizada com sucesso");
+            Logger::info("Senha atualizada com sucesso", ["id" => $id]);
             \redirect('/dashboard');
 
         } catch (\Exception $e) {
-            if ($e->getMessage() == "DATABASE_ERROR") { 
+            if ($e->getMessage() == "DATABASE_ERROR") {
                 $erros = "Hove um erro ao atualizar informações da conta";
-                $log->info("Erro ao atualizar informações da conta");
             } else {
                 $erros = "Erro desconhecido";
             }
+            Logger::error("Erro ao atualizar informações da conta", ["id" => $id, "error" => $e->getMessage()]);
             return $erros;
         }
     }

--- a/Core/Database.php
+++ b/Core/Database.php
@@ -2,13 +2,9 @@
 
 namespace Core;
 
-use Dotenv\Dotenv;
 use Exception;
 use PDO;
 use PDOException;
-use Monolog\Level;
-use Monolog\Logger;
-use Monolog\Handler\StreamHandler;
 
 class Database
 {
@@ -19,15 +15,6 @@ class Database
 
     public function __construct()
     {
-
-        // Carregar variáveis do .env
-        $dotenv = Dotenv::createImmutable(__DIR__ . '/../');
-        $dotenv->load();
-
-        //log
-        $log = new Logger("conexão com banco de dados ");
-        $log->pushHandler(new StreamHandler("../logs/database.log", Level::Warning));
-
         // Criar array de configuração
         $config = [
             "host" => $_ENV['DB_HOST'],

--- a/Core/Feedback.php
+++ b/Core/Feedback.php
@@ -3,11 +3,7 @@
 namespace Core;
 
 use Core\Models\FeedbackModel;
-use Dotenv\Dotenv;
 use Core\Validator;
-use Monolog\Level;
-use Monolog\Logger;
-use Monolog\Handler\StreamHandler;
 
 class Feedback
 {
@@ -20,12 +16,6 @@ class Feedback
 
     public function createFeedback($name, $email, $body, $currentId)
     {
-        $log = new Logger("Feedback usuario ");
-        $log->pushHandler(new StreamHandler("../logs/feedback.log", Level::Info));
-
-        $dotenv = Dotenv::createImmutable(__DIR__ . '/../');
-        $dotenv->load();
-
         try {
             $erros = [];
             if (!Validator::string($name, 3, 50)) {
@@ -52,7 +42,7 @@ class Feedback
             $subject = "Feedback da plataforma NoteSync";
 
             App::resolve(EmailProvider::class)->sendEmail($email, $name, $body, $subject);
-            $log->info("Feedback enviado com sucesso");
+            Logger::info("Feedback enviado com sucesso");
 
             redirect("/feedback");
         } catch (\Exception $e) {
@@ -61,7 +51,7 @@ class Feedback
             } else {
                 $erros["erro"] = "Erro desconhecido";
             }
-            $log->error($e);
+            Logger::error("Erro ao enviar o feedback", ["error" => $e->getMessage()]);
 
             Session::flash("erros", $erros);
             Session::flash("old", [

--- a/Core/Logger.php
+++ b/Core/Logger.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Core;
+
+use Monolog\Formatter\LineFormatter;
+use Monolog\Level;
+use Monolog\Logger as Monologger;
+use Monolog\Handler\StreamHandler;
+
+class Logger
+{
+  protected static $instance;
+
+  /**
+   * Method to return the Monolog instance
+   *
+   * @return Monologger
+   */
+  static public function getLogger()
+  {
+    if (!self::$instance) {
+      self::configureInstance();
+    }
+
+    return self::$instance;
+  }
+
+  protected static function configureInstance()
+  {
+    $logger = new Monologger($_ENV['APP_NAME']);
+
+    //format a mensagem de log. Ex.: [2021-08-01 00:00:00] [ERROR] Mensagem de log {"context": "contexto"}
+    $output = "[%datetime%] [%level_name%] %message% %context% %extra%\n";
+    $formatter = new LineFormatter($output);
+    $stream = new StreamHandler($_ENV["LOG_FILE"], Level::Debug);
+    $stream->setFormatter($formatter);
+
+    $logger->pushHandler($stream);
+    self::$instance = $logger;
+  }
+
+  protected static function log($level, $message, array $context = [])
+  {
+    $backtrace = debug_backtrace();
+    $class = $backtrace[2]['class'];
+    $method = $backtrace[2]['function'];
+    $message = "[$class::$method] $message";
+    self::getLogger()->log($level, $message, $context);
+  }
+
+  public static function debug($message, array $context = [])
+  {
+    self::log(Level::Debug, $message, $context);
+  }
+
+  public static function info($message, array $context = [])
+  {
+    self::log(Level::Info, $message, $context);
+  }
+
+  public static function warn($message, array $context = [])
+  {
+    self::log(Level::Warning, $message, $context);
+  }
+
+  public static function error($message, array $context = [])
+  {
+    self::log(Level::Error, $message, $context);
+  }
+
+}

--- a/Core/Notes.php
+++ b/Core/Notes.php
@@ -5,9 +5,6 @@ namespace Core;
 use Core\Models\NotesModel;
 use Core\Validator;
 use Monolog\Level;
-use Monolog\Logger;
-use Monolog\Handler\StreamHandler;
-use Core\Model;
 
 class Notes
 {
@@ -25,9 +22,6 @@ class Notes
     public function createNote($body, $currentId)
     {
 
-        $log = new Logger("registro de notas ");
-        $log->pushHandler(new StreamHandler("../logs/notes.log", Level::Info));
-
         try {
             $erros = [];
             if (!Validator::string($body, 10, 255)) {
@@ -39,17 +33,17 @@ class Notes
                     "user_id" => $currentId
                 ]);
 
-                $log->info("nota criada com sucesso");
+                Logger::info("Nota criada com sucesso");
                 return true; 
             }
             return $erros; 
         } catch (\Exception $e) {
             if($e->getMessage() == "DATABASE_ERROR") {
                 $erros["body"] = "Houve um erro ao criar nota";
-                $log->error("Houve um erro ao criar nota {Class - Notes}");
             } else {
                 $erros["body"] = "Erro desconhecido";
             }
+            Logger::error("Erro ao criar nota", ["error" => $e->getMessage()]);
             return $erros;
         }
     }
@@ -101,9 +95,6 @@ class Notes
 
     public function updateNote($id, $body, $currentId)
     {
-        $log = new Logger("Atualização da nota ");
-        $log->pushHandler(new StreamHandler("../logs/notes.log", Level::Info));
-
         try {
             $note = $this->notesModel->find($id);
             autorize($note["user_id"] === $currentId);
@@ -113,27 +104,23 @@ class Notes
             }
             if (empty($erros)) {
                 $this->notesModel->updateNote($id, $body);
-                $log->info("nota atualizada com sucesso");
+                Logger::info("nota atualizada com sucesso");
                 return true;
             }
             return $erros;
         } catch (\Exception $e) {
             if($e->getMessage() == "DATABASE_ERROR") {
                 $erros["body"] = "Houve um erro ao atualizar nota";
-                $log->error("Houve um erro ao atualizar nota {Class - Notes}");
             } else {
                 $erros = "Erro desconhecido"; 
             }
+            Logger::error("Erro ao atualizar nota", ["error" => $e->getMessage()]);
             return $erros;
         }
     }
     
     public function deleteNoteById($id, $currentId)
     {
-
-        $log = new Logger("Deletar nota ");
-        $log->pushHandler(new StreamHandler("../logs/notes.log", Level::Info));
-
         try {
             $note = $this->notesModel->find($id);
             autorize($note["user_id"] === $currentId);
@@ -144,15 +131,15 @@ class Notes
                 return false;
             }
     
-            $log->info("nota deletada com sucesso");
+            Logger::info("nota deletada com sucesso");
             redirect("/notes");
         } catch (\Exception $e) {
             if($e->getMessage() == "DATABASE_ERROR") {
                 $erros["body"] = "Houve um erro ao deletar nota";
-                $log->info("Houve um erro ao deletar nota {Class - Notes}");
             } else {
                 $erros["body"] = "Erro desconhecido";
             }
+            Logger::error("Erro ao deletar nota", ["error" => $e->getMessage()]);
         }
     }
 }

--- a/Core/Session.php
+++ b/Core/Session.php
@@ -39,6 +39,7 @@ class Session
     {
         static::flush();
         session_destroy();
+        Logger::debug("Sessão destruída");
 
         $parameters = session_get_cookie_params();
         setcookie("PHPSESSID", "", time() - 3600, $parameters["path"], $parameters["domain"], $parameters["secure"], $parameters["httponly"]);

--- a/Core/UserLogin.php
+++ b/Core/UserLogin.php
@@ -5,35 +5,30 @@ namespace Core;
 use Core\Authenticator;
 use Core\Session;
 use Http\Form\LoginForm;
-use Monolog\Level;
-use Monolog\Logger;
-use Monolog\Handler\StreamHandler;
 
 
 class UserLogin
 {
     public function login($email, $password)
     {
-       $log = new Logger('registro de usuario ');
-       $log->pushHandler(new StreamHandler('../logs/login.log', Level::Info));
-
         $form = new LoginForm();
         try {
             if ($form->validate($email, $password)) {
                 if ((new Authenticator)->attempt($email, $password)) {
-                    $log->info('login realizado com sucesso');
+                    Logger::info('login realizado com sucesso');
                     redirect("/dashboard");
                 } else {
                     $form->erro("email", "Email ou senha estão incorretos");
+                    Logger::warn("Tentativa de login com credenciais inválidas");
                 }
             }
         } catch (\Exception $e) {
             if ($e->getMessage() == "DATABASE_ERROR") {
                 $form->erro("email", "Houve um erro ao realizar login");
-                $log->error("erro ao realizar login {Class - Login}");
             } else {
                 $form->erro("email", "Erro desconhecido");
             }
+            Logger::error("Erro ao realizar login", ["error" => $e->getMessage()]);
         }
         Session::flash("erros", $form->erros());
         Session::flash("old", ["email" => $email]);

--- a/Core/UserRegistration.php
+++ b/Core/UserRegistration.php
@@ -2,10 +2,6 @@
 
 namespace Core;
 
-use Monolog\Level;
-use Monolog\Logger;
-use Monolog\Handler\StreamHandler;
-use Core\Model;
 use Core\Models\UsersModel;
 
 class UserRegistration
@@ -20,10 +16,6 @@ class UserRegistration
 
     public function registerUser($email, $password)
     {
-
-        // create a log channel
-        $log = new Logger("registro de usuario ");
-        $log->pushHandler(new StreamHandler("../logs/register.log", Level::Info));
 
         try {
             if (!Validator::email($email)) {
@@ -42,6 +34,7 @@ class UserRegistration
 
             if ($user) {
                 $erros["email"] = "Já existe uma conta cadastrada com este email. Por favor, tente com outro email.";
+                Logger::warn("Tentativa de registro com email já cadastrado");
                 return $erros;
             } else {
                 $id = $this->usersModel->register($email, $password);
@@ -52,16 +45,16 @@ class UserRegistration
                 ];
 
                 
-                $log->info("registrado com sucesso");
+                Logger::info("registrado com sucesso");
                 redirect("/dashboard");
             }
         } catch (\Exception $e) {
             if ($e->getMessage() == "DATABASE_ERROR") {
                 $erros["password"] = "Houve um erro ao registrar usuário";
-                $log->error("erro a registrar {Class - UserRegistration}");
             } else {
                 $erros["password"] = "Erro desconhecido";
             }
+            Logger::error("Erro a registrar", ["error" => $e->getMessage()]);
             return $erros;
         }
     }

--- a/public/index.php
+++ b/public/index.php
@@ -1,9 +1,14 @@
 <?php
 
 use Core\Session;
+use Dotenv\Dotenv;
 
 const BASE_PATH = __DIR__ . '/../';
 require BASE_PATH . "vendor/autoload.php";
+
+// Carregar variáveis do .env
+$dotenv = Dotenv::createImmutable(__DIR__ . '/../');
+$dotenv->load();
 
 session_start();
 


### PR DESCRIPTION
- Cria uma classe estática para centralizar e permitir chamar o logger de qualquer parte da aplicação
- Adiciona o nome da classe e método onde o log foi chamado
- Refatora o uso do logger
- Move a leitura do arquivo `.env` para o início da aplicação para evitar erros

![image](https://github.com/luizfspintoo/note-sync/assets/13575331/ef084482-6e16-421b-b33b-42e964715b9d)


Mais detalhes nos comentários do código